### PR TITLE
chore: remove duplicate cache ignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,9 +91,8 @@ dist
 # vuepress build output
 .vuepress/dist
 
-# vuepress v2.x temp and cache directory
+# vuepress v2.x temp directory
 .temp
-.cache
 
 # Sveltekit cache directory
 .svelte-kit/


### PR DESCRIPTION
## Summary
- remove redundant `.cache` ignore rule
- clarify vuepress temp directory comment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cee3a85c88332ad50cdce2d1a863b